### PR TITLE
[charts] Fix StorageClass mountOptions

### DIFF
--- a/charts/vastcsi/templates/storage-class.yaml
+++ b/charts/vastcsi/templates/storage-class.yaml
@@ -42,7 +42,7 @@
 {{- $volume_name_fmt := pluck "volumeNameFormat" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $eph_volume_name_fmt := pluck "ephemeralVolumeNameFormat" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $qos_policy :=  pluck "qosPolicy" $options $.Values.storageClassDefaults | first | quote -}}
-{{- $mount_options :=  pluck "mountOptions" $options $.Values.storageClassDefaults | first | quote -}}
+{{- $mount_options :=  pluck "mountOptions" $options $.Values.storageClassDefaults | first -}}
 {{-
    $allow_volume_expansion := pluck "allowVolumeExpansion" $options $.Values.storageClassDefaults |
    first | quote | mustRegexMatch "true" | ternary true false
@@ -69,7 +69,7 @@ parameters:
   qos_policy: {{ $qos_policy }}
   {{- end }}
 allowVolumeExpansion: {{ $allow_volume_expansion }}
-mountOptions:
-  - {{ $mount_options }}
+mountOptions: 
+{{ toYaml $mount_options | indent 2 }}
 ---
 {{- end }}

--- a/charts/vastcsi/values.yaml
+++ b/charts/vastcsi/values.yaml
@@ -53,7 +53,7 @@ storageClassDefaults:
   # String template for CSI-provisioned ephemeral volumes, within VAST
   ephemeralVolumeNameFormat: "csi:{namespace}:{name}:{id}"
   # Add any extra NFS options desired here
-  mountOptions: ""
+  mountOptions: []
   # Name of QoS policy associates with the view.
   qosPolicy: ""
 


### PR DESCRIPTION
StorageClass mountOptions seems not working.

With values :

```yaml
storageClasses:
  vastdata-filesystem:
    vipPool: vippoolname
    storagePath: "/kubepath"
    viewPolicy: kube_csi
    volumeNameFormat: "csi:kube:{namespace}:{name}:{id}"
    ephemeralVolumeNameFormat: "csi:kube:{namespace}:{name}:{id}"
    mountOptions: 
      - proto=tcp
      - port=2049
      - nfsvers=4
```

Generated StorageClass do not work :

```yaml
# Source: vastcsi/templates/storage-class.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
provisioner: csi.vastdata.com
# ...
mountOptions:
  - "[proto=tcp port=2049 nfsvers=4]"
```

With this PR :

```yaml
# Source: vastcsi/templates/storage-class.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
provisioner: csi.vastdata.com
# ...
mountOptions: 
  - proto=tcp
  - port=2049
  - nfsvers=4
```