### PR TITLE
feat(chart): configurable reclaimPolicy on storage class

### DIFF
--- a/charts/vastcsi/templates/storage-class.yaml
+++ b/charts/vastcsi/templates/storage-class.yaml
@@ -43,6 +43,7 @@
 {{- $eph_volume_name_fmt := pluck "ephemeralVolumeNameFormat" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $qos_policy :=  pluck "qosPolicy" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $mount_options :=  pluck "mountOptions" $options $.Values.storageClassDefaults | first -}}
+{{- $reclaim_policy :=  pluck "reclaimPolicy" $options $.Values.storageClassDefaults | first | quote -}}
 {{-
    $allow_volume_expansion := pluck "allowVolumeExpansion" $options $.Values.storageClassDefaults |
    first | quote | mustRegexMatch "true" | ternary true false
@@ -58,6 +59,9 @@ metadata:
     storageclass.kubernetes.io/is-default-class: {{ $is_default_class }}
   labels:
   {{- include "vastcsi.labels" $ | nindent 4 }}
+{{- if ne $reclaim_policy (quote "") }}
+reclaimPolicy: {{ $reclaim_policy }}
+{{- end }}
 parameters:
   vip_pool_name: {{ $vip_pool_name }}
   root_export: {{ $storage_path }}

--- a/charts/vastcsi/values.yaml
+++ b/charts/vastcsi/values.yaml
@@ -63,6 +63,8 @@ storageClassDefaults:
   mountOptions: []
   # Name of QoS policy associates with the view.
   qosPolicy: ""
+  # Reclaim policy to use with the storage class.
+  reclaimPolicy: ""
 
 # Default storage class to use with CSI DRIVER.
 # The only required value is 'vipPool' name where user should provide name of existing vip pool on

--- a/charts/vastcsi/values.yaml
+++ b/charts/vastcsi/values.yaml
@@ -64,7 +64,7 @@ storageClassDefaults:
   # Name of QoS policy associates with the view.
   qosPolicy: ""
   # Reclaim policy to use with the storage class.
-  reclaimPolicy: ""
+  reclaimPolicy: "Delete"
 
 # Default storage class to use with CSI DRIVER.
 # The only required value is 'vipPool' name where user should provide name of existing vip pool on


### PR DESCRIPTION
Hello,

As far as I could see, the [relaimPolicy entry](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) was not editable during storage class templating in the charts.

We are using them to create a retain storage class in our clusters. As a result, this PR proposes an integration of the feature.

Feel free to review the integration and let me know if it requires any changes.