### PR TITLE
Update storage-class.yaml

### DIFF
--- a/charts/vastcsi/templates/storage-class.yaml
+++ b/charts/vastcsi/templates/storage-class.yaml
@@ -56,7 +56,6 @@ metadata:
   {{- include "vastcsi.labels" $ | nindent 4 }}
 reclaimPolicy: {{ $reclaim_policy }}
 parameters:
-  vip_pool_name: {{ $vip_pool_name }}
   root_export: {{ $storage_path }}
   view_policy: {{ $view_policy }}
   lb_strategy: {{ $lb_strategy }}


### PR DESCRIPTION
Removing duplicate vip_pool_name parameter that is causing a templating error.

Helm install failed for release vast-csi/vast-csi with chart vastcsi@2.4.0: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 25: mapping key "vip_pool_name" already defined at line 19