### PR TITLE
block: add volume_encryption flag for dm-crypt support

### DIFF
--- a/charts/vastblock/templates/node.yaml
+++ b/charts/vastblock/templates/node.yaml
@@ -39,6 +39,7 @@ spec:
           {{- toYaml .Values.node.podAntiAffinity | nindent 10 }}
         nodeAffinity:
           {{- toYaml .Values.node.nodeAffinity | nindent 10 }}
+      hostIPC: true
       containers:
         - name: csi-node-driver-registrar
           image: {{ printf "%s:%s" $csi_images.csiNodeDriverRegistrar.repository (toString $csi_images.csiNodeDriverRegistrar.tag) }}

--- a/charts/vastblock/templates/shared/_helpers.tpl
+++ b/charts/vastblock/templates/shared/_helpers.tpl
@@ -64,3 +64,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "vastcsi.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+{{- define "vastcsi.dictToYaml" -}}
+{{- $input := index . 0 -}}        {{/* The map to render */}}
+{{- $prefix := index . 1 | default "" -}}  {{/* Optional prefix for keys */}}
+{{- if not (kindIs "map" $input) }}
+  {{- $errorMsg := printf "Invalid format. Expected a dictionary but got:\n%s" (toYaml $input) }}
+  {{- fail $errorMsg }}
+{{- else }}
+  {{- range $k, $v := $input }}
+    {{- if and $v (ne $v "") }}
+{{ printf "%s%s: %s" $prefix $k ($v | quote) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/vastblock/templates/storage-class.yaml
+++ b/charts/vastblock/templates/storage-class.yaml
@@ -26,7 +26,6 @@
 
 {{- $tenant_name := pluck "tenantName" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $volume_group := pluck "volumeGroup" $options $.Values.storageClassDefaults | first | quote -}}
-{{- $volume_encryption := pluck "volumeEncryption" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $mount_options :=  pluck "mountOptions" $options $.Values.storageClassDefaults | first -}}
 {{- $reclaim_policy :=  pluck "reclaimPolicy" $options $.Values.storageClassDefaults | first | quote -}}
 {{-
@@ -39,7 +38,7 @@
 {{- $storage_class_secret_namespace := pluck "secretNamespace" $options $.Values.storageClassDefaults | first | default $.Release.Namespace | quote -}}
 {{- $fstype := pluck "fsType" $options $.Values.storageClassDefaults | first -}}
 {{- $transport_type := pluck "transportType" $options $.Values.storageClassDefaults | first -}}
-
+{{- $host_encryption := pluck "host_encryption" $options $.Values.storageClassDefaults | first | default dict -}}
 
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -54,10 +53,13 @@ metadata:
 reclaimPolicy: {{ $reclaim_policy }}
 parameters:
   subsystem: {{ $subsystem }}
-{{- range $key, $value := dict "vip_pool_name" $vip_pool_name "vip_pool_fqdn" $vip_pool_fqdn "volume_group" $volume_group "volume_encryption" $volume_encryption "transport_type" $transport_type "fsType" $fstype "tenant_name" $tenant_name }}
+{{- range $key, $value := dict "vip_pool_name" $vip_pool_name "vip_pool_fqdn" $vip_pool_fqdn "volume_group" $volume_group "transport_type" $transport_type "fsType" $fstype "tenant_name" $tenant_name }}
   {{- if and $value (ne $value ( quote "" )) }}
   {{ $key }}: {{ if (kindIs "int" $value) }}{{ $value | quote }}{{ else }}{{ $value }}{{ end }}
   {{- end }}
+{{- end }}
+{{- if $host_encryption }}
+{{- include "vastcsi.dictToYaml" (list $host_encryption "host_encryption.") | indent 2 }}
 {{- end }}
 {{-  if ne $storage_class_secret ( quote "" ) }}
   csi.storage.k8s.io/provisioner-secret-name: {{ $storage_class_secret }}

--- a/charts/vastblock/templates/storage-class.yaml
+++ b/charts/vastblock/templates/storage-class.yaml
@@ -26,6 +26,7 @@
 
 {{- $tenant_name := pluck "tenantName" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $volume_group := pluck "volumeGroup" $options $.Values.storageClassDefaults | first | quote -}}
+{{- $volume_encryption := pluck "volumeEncryption" $options $.Values.storageClassDefaults | first | quote -}}
 {{- $mount_options :=  pluck "mountOptions" $options $.Values.storageClassDefaults | first -}}
 {{- $reclaim_policy :=  pluck "reclaimPolicy" $options $.Values.storageClassDefaults | first | quote -}}
 {{-
@@ -53,7 +54,7 @@ metadata:
 reclaimPolicy: {{ $reclaim_policy }}
 parameters:
   subsystem: {{ $subsystem }}
-{{- range $key, $value := dict "vip_pool_name" $vip_pool_name "vip_pool_fqdn" $vip_pool_fqdn "volume_group" $volume_group "transport_type" $transport_type "fsType" $fstype "tenant_name" $tenant_name }}
+{{- range $key, $value := dict "vip_pool_name" $vip_pool_name "vip_pool_fqdn" $vip_pool_fqdn "volume_group" $volume_group "volume_encryption" $volume_encryption "transport_type" $transport_type "fsType" $fstype "tenant_name" $tenant_name }}
   {{- if and $value (ne $value ( quote "" )) }}
   {{ $key }}: {{ if (kindIs "int" $value) }}{{ $value | quote }}{{ else }}{{ $value }}{{ end }}
   {{- end }}

--- a/charts/vastblock/values.yaml
+++ b/charts/vastblock/values.yaml
@@ -59,20 +59,19 @@ storageClassDefaults:
   #   - "folder1/folder2/block-{namespace}-{id}
   volumeGroup: ""
   # Enables encryption using LUKS on the device on the client side.
-  # If set to true, the CSI driver will expect a volume-specific secret to be provided
-  # with the encryption passphrase.
-  # This secret must be referenced in the StorageClass with the keys:
-  #   csi.storage.k8s.io/volume-secret-name: <secret-name>
-  #   csi.storage.k8s.io/volume-secret-namespace: <namespace>
+  # If set to true, the CSI driver will expect a passphrase to be provided
+  # with the vast-mgmt secret.
 
-  # Example Kubernetes Secret for volume encryption:
-  #     kubectl create secret generic volume-secret-namespace \
-  #     --from-literal=passphrase='my-secret-pass'
+  # Example Kubernetes Secret for host encryption:
+  # kubectl create secret generic vast-mgmt --from-literal=username='' --from-literal=password='' --from-literal=endpoint='' --from-literal=passphrase=''
 
-  # Ensure the StorageClass has the following parameters set when volume_encryption is true:
-  #   csi.storage.k8s.io/volume-secret-name: volume-secret
-  #   csi.storage.k8s.io/volume-secret-namespace: default
-  volume_encryption: true
+  # Ensure the StorageClass has the following parameters set when host Encryption is true:
+  # Optional host encryption parameters (will default if not specified):
+  #   cipher: "aes-xts-plain64"           # Encryption cipher
+  #   key_size: "512"                     # Key size in bits (e.g., 256 or 512)
+  #   hash: "sha256"                      # Hashing algorithm
+  #   pbkdf_memory: "65536"               # Memory cost for PBKDF in KB
+  host_encryption: {}
   # Name of VAST VIP pool to use. Must specify either vipPool or vipPoolFQDN.
   vipPool: ""
   # The FQDN of the VIP pool to use. Must specify either vipPool or vipPoolFQDN.

--- a/charts/vastblock/values.yaml
+++ b/charts/vastblock/values.yaml
@@ -58,6 +58,21 @@ storageClassDefaults:
   # can represent nested folder structures. For example:
   #   - "folder1/folder2/block-{namespace}-{id}
   volumeGroup: ""
+  # Enables encryption using LUKS on the device on the client side.
+  # If set to true, the CSI driver will expect a volume-specific secret to be provided
+  # with the encryption passphrase.
+  # This secret must be referenced in the StorageClass with the keys:
+  #   csi.storage.k8s.io/volume-secret-name: <secret-name>
+  #   csi.storage.k8s.io/volume-secret-namespace: <namespace>
+
+  # Example Kubernetes Secret for volume encryption:
+  #     kubectl create secret generic volume-secret-namespace \
+  #     --from-literal=passphrase='my-secret-pass'
+
+  # Ensure the StorageClass has the following parameters set when volume_encryption is true:
+  #   csi.storage.k8s.io/volume-secret-name: volume-secret
+  #   csi.storage.k8s.io/volume-secret-namespace: default
+  volume_encryption: true
   # Name of VAST VIP pool to use. Must specify either vipPool or vipPoolFQDN.
   vipPool: ""
   # The FQDN of the VIP pool to use. Must specify either vipPool or vipPoolFQDN.

--- a/examples/block/sc-vol-encryption.yaml
+++ b/examples/block/sc-vol-encryption.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: vastdata-block
+parameters:
+  csi.storage.k8s.io/controller-expand-secret-name: vast-mgmt
+  csi.storage.k8s.io/controller-expand-secret-namespace: default
+  csi.storage.k8s.io/controller-publish-secret-name: vast-mgmt
+  csi.storage.k8s.io/controller-publish-secret-namespace: default
+  csi.storage.k8s.io/provisioner-secret-name: vast-mgmt
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  subsystem: myblock
+  vip_pool_name: vip1
+  transport_type: TCP
+  volume_encryption: "true"
+  csi.storage.k8s.io/volume-secret-name: volume-secret
+  csi.storage.k8s.io/volume-secret-namespace: default
+provisioner: block.csi.vastdata.com

--- a/examples/block/sc-with-host-encryption.yaml
+++ b/examples/block/sc-with-host-encryption.yaml
@@ -9,10 +9,10 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-namespace: default
   csi.storage.k8s.io/provisioner-secret-name: vast-mgmt
   csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: vast-mgmt
+  csi.storage.k8s.io/node-stage-secret-namespace: default
   subsystem: myblock
-  vip_pool_name: vip1
+  vip_pool_name: vippool-1
   transport_type: TCP
-  volume_encryption: "true"
-  csi.storage.k8s.io/volume-secret-name: volume-secret
-  csi.storage.k8s.io/volume-secret-namespace: default
+  host_encryption: '{"luks_type":"luks2","cipher":"aes-xts-plain64"}'
 provisioner: block.csi.vastdata.com

--- a/vast_csi/block_utils.py
+++ b/vast_csi/block_utils.py
@@ -30,6 +30,43 @@ def is_native_multipath_enabled():
     except Exception:
         return False
 
+def is_luks_device(device_path: str) -> bool:
+    """
+    Check if the given device is a LUKS-encrypted volume.
+
+    Args:
+        device_path (str): The path to the block device.
+
+    Returns:
+        bool: True if the device is LUKS, False otherwise.
+    """
+    try:
+        run(["cryptsetup", "isLuks", device_path])
+        return True
+    except ProcessExecutionError:
+        return False
+
+def is_crypto_luks(device_path):
+    """
+    Determines whether the given device is a LUKS-encrypted block device.
+
+    Args:
+        device_path (str): The path to the block device (e.g., /dev/nvme0n1).
+
+    Returns:
+        bool: True if the device is using LUKS encryption (FSTYPE is crypto_LUKS), False otherwise.
+    """
+    try:
+        result = subprocess.run(
+            ['lsblk', '-no', 'FSTYPE', device_path],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True
+        )
+        return result.stdout.strip() == 'crypto_LUKS'
+    except subprocess.CalledProcessError:
+        return False
 
 def list_nvme_sessions():
     """

--- a/vast_csi/block_utils.py
+++ b/vast_csi/block_utils.py
@@ -30,44 +30,6 @@ def is_native_multipath_enabled():
     except Exception:
         return False
 
-def is_luks_device(device_path: str) -> bool:
-    """
-    Check if the given device is a LUKS-encrypted volume.
-
-    Args:
-        device_path (str): The path to the block device.
-
-    Returns:
-        bool: True if the device is LUKS, False otherwise.
-    """
-    try:
-        run(["cryptsetup", "isLuks", device_path])
-        return True
-    except ProcessExecutionError:
-        return False
-
-def is_crypto_luks(device_path):
-    """
-    Determines whether the given device is a LUKS-encrypted block device.
-
-    Args:
-        device_path (str): The path to the block device (e.g., /dev/nvme0n1).
-
-    Returns:
-        bool: True if the device is using LUKS encryption (FSTYPE is crypto_LUKS), False otherwise.
-    """
-    try:
-        result = subprocess.run(
-            ['lsblk', '-no', 'FSTYPE', device_path],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True
-        )
-        return result.stdout.strip() == 'crypto_LUKS'
-    except subprocess.CalledProcessError:
-        return False
-
 def list_nvme_sessions():
     """
     Example output:

--- a/vast_csi/builders/block.py
+++ b/vast_csi/builders/block.py
@@ -1,4 +1,5 @@
 import os
+import json
 from datetime import timedelta
 from dataclasses import dataclass
 from typing import final, Optional
@@ -37,7 +38,7 @@ class BlockProvisionBase(BaseVolumeBuilder):
     capacity_range: Optional[int] = None
     pvc_name: Optional[str] = None
     pvc_namespace: Optional[str] = None
-    volume_encryption: Optional[str] = None
+    host_encryption: Optional[dict] = None
     volume_content_source: Optional[types.VolumeContentSource] = None  # Either volume or snapshot
 
     @classmethod
@@ -57,7 +58,7 @@ class BlockProvisionBase(BaseVolumeBuilder):
         vip_pool_fqdn = parameters.get("vip_pool_fqdn")
         vip_pool_name = parameters.get("vip_pool_name")
         volume_group = parameters.get("volume_group", "")
-        volume_encryption = parameters.get("volume_encryption", "False")
+        host_encryption = cls._parse_host_encryption(parameters)
         transport_type = parameters.get("transport_type", "TCP").upper()
         metadata = cls._parse_metadata_from_params(parameters)
         cls._validate_mount_src(vip_pool_name, vip_pool_fqdn, conf.use_local_ip_for_mount)
@@ -73,9 +74,9 @@ class BlockProvisionBase(BaseVolumeBuilder):
             tenant_name=tenant_name,
             transport_type=transport_type,
             volume_group=volume_group,
-            volume_encryption=volume_encryption,
             vip_pool_name=vip_pool_name,
             vip_pool_fqdn=vip_pool_fqdn,
+            host_encryption=host_encryption,
             cluster_name=cluster_name,
             volume_content_source=volume_content_source,
             **metadata,
@@ -104,6 +105,16 @@ class BlockProvisionBase(BaseVolumeBuilder):
         # make sure the volume group is a valid absolute path
         return os.path.join("/", volume_group, self.name).lstrip("/")
 
+    @staticmethod
+    def _parse_host_encryption(params):
+        host_encryption = params.get("host_encryption", {})
+        if isinstance(host_encryption, str):
+            try:
+                host_encryption = json.loads(host_encryption)
+            except json.JSONDecodeError:
+                host_encryption = {}
+        return host_encryption
+
     @property
     def volume_context(self) -> dict:
         context = {
@@ -116,8 +127,9 @@ class BlockProvisionBase(BaseVolumeBuilder):
             context["vip_pool_name"] = self.vip_pool_name
         elif self.vip_pool_fqdn:
             context["vip_pool_fqdn"] = self.vip_pool_fqdn_with_prefix
-        if self.volume_encryption:
-            context["volume_encryption"] = self.volume_encryption
+        if self.host_encryption:
+            for key, value in self.host_encryption.items():
+                context[f"host_encryption.{key}"] = value
         return context
 
 
@@ -282,7 +294,6 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
     cluster_name: Optional[str] = None
     vip_pool_name: Optional[str] = None
     vip_pool_fqdn: Optional[str] = None
-    volume_encryption: Optional[str] None
     transport_type: Optional[str] = "TCP"
 
     @classmethod
@@ -300,7 +311,6 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
         vip_pool_fqdn = parameters.get("vip_pool_fqdn")
         vip_pool_name = parameters.get("vip_pool_name")
         transport_type = parameters.get("transport_type", "TCP").upper()
-        volume_encryption = parameters.get("volume_encryption")
         cls._validate_mount_src(vip_pool_name, vip_pool_fqdn, conf.use_local_ip_for_mount)
         cluster_name = parameters.get("cluster_name")
         return cls(
@@ -314,7 +324,6 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
             vip_pool_fqdn=vip_pool_fqdn,
             transport_type=transport_type,
             cluster_name=cluster_name,
-            volume_encryption=volume_encryption,
         )
 
     @property
@@ -329,8 +338,6 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
             context["vip_pool_name"] = self.vip_pool_name
         elif self.vip_pool_fqdn:
             context["vip_pool_fqdn"] = self.vip_pool_fqdn_with_prefix
-        if self.volume_encryption:
-            context["volume_encryption"] = self.volume_encryption
         return context
 
     def build_volume(self) -> types.Volume:

--- a/vast_csi/builders/block.py
+++ b/vast_csi/builders/block.py
@@ -37,6 +37,7 @@ class BlockProvisionBase(BaseVolumeBuilder):
     capacity_range: Optional[int] = None
     pvc_name: Optional[str] = None
     pvc_namespace: Optional[str] = None
+    volume_encryption: Optional[str] = None
     volume_content_source: Optional[types.VolumeContentSource] = None  # Either volume or snapshot
 
     @classmethod
@@ -56,6 +57,7 @@ class BlockProvisionBase(BaseVolumeBuilder):
         vip_pool_fqdn = parameters.get("vip_pool_fqdn")
         vip_pool_name = parameters.get("vip_pool_name")
         volume_group = parameters.get("volume_group", "")
+        volume_encryption = parameters.get("volume_encryption", "False")
         transport_type = parameters.get("transport_type", "TCP").upper()
         metadata = cls._parse_metadata_from_params(parameters)
         cls._validate_mount_src(vip_pool_name, vip_pool_fqdn, conf.use_local_ip_for_mount)
@@ -71,6 +73,7 @@ class BlockProvisionBase(BaseVolumeBuilder):
             tenant_name=tenant_name,
             transport_type=transport_type,
             volume_group=volume_group,
+            volume_encryption=volume_encryption,
             vip_pool_name=vip_pool_name,
             vip_pool_fqdn=vip_pool_fqdn,
             cluster_name=cluster_name,
@@ -113,6 +116,8 @@ class BlockProvisionBase(BaseVolumeBuilder):
             context["vip_pool_name"] = self.vip_pool_name
         elif self.vip_pool_fqdn:
             context["vip_pool_fqdn"] = self.vip_pool_fqdn_with_prefix
+        if self.volume_encryption:
+            context["volume_encryption"] = self.volume_encryption
         return context
 
 
@@ -277,6 +282,7 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
     cluster_name: Optional[str] = None
     vip_pool_name: Optional[str] = None
     vip_pool_fqdn: Optional[str] = None
+    volume_encryption: Optional[str] None
     transport_type: Optional[str] = "TCP"
 
     @classmethod
@@ -294,6 +300,7 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
         vip_pool_fqdn = parameters.get("vip_pool_fqdn")
         vip_pool_name = parameters.get("vip_pool_name")
         transport_type = parameters.get("transport_type", "TCP").upper()
+        volume_encryption = parameters.get("volume_encryption")
         cls._validate_mount_src(vip_pool_name, vip_pool_fqdn, conf.use_local_ip_for_mount)
         cluster_name = parameters.get("cluster_name")
         return cls(
@@ -307,6 +314,7 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
             vip_pool_fqdn=vip_pool_fqdn,
             transport_type=transport_type,
             cluster_name=cluster_name,
+            volume_encryption=volume_encryption,
         )
 
     @property
@@ -321,6 +329,8 @@ class StaticBlockVolumeBuilder(BaseVolumeBuilder):
             context["vip_pool_name"] = self.vip_pool_name
         elif self.vip_pool_fqdn:
             context["vip_pool_fqdn"] = self.vip_pool_fqdn_with_prefix
+        if self.volume_encryption:
+            context["volume_encryption"] = self.volume_encryption
         return context
 
     def build_volume(self) -> types.Volume:

--- a/vast_csi/builders/test.py
+++ b/vast_csi/builders/test.py
@@ -27,6 +27,7 @@ class TestVolumeBuilder(BaseVolumeBuilder):
     cluster_name: Optional[str] = None
     vip_pool_name: Optional[str] = None
     vip_pool_fqdn: Optional[str] = None
+    volume_encryption: Optional[str] = None
     qos_policy: Optional[str] = None
     capacity_range: Optional[int] = None  # Optional desired volume capacity
     pvc_name: Optional[str] = None

--- a/vast_csi/builders/test.py
+++ b/vast_csi/builders/test.py
@@ -27,7 +27,7 @@ class TestVolumeBuilder(BaseVolumeBuilder):
     cluster_name: Optional[str] = None
     vip_pool_name: Optional[str] = None
     vip_pool_fqdn: Optional[str] = None
-    volume_encryption: Optional[str] = None
+    host_encryption: Optional[dict] = None
     qos_policy: Optional[str] = None
     capacity_range: Optional[int] = None  # Optional desired volume capacity
     pvc_name: Optional[str] = None

--- a/vast_csi/filesystem_utils.py
+++ b/vast_csi/filesystem_utils.py
@@ -338,9 +338,12 @@ def need_resize(device: str, target_mount, fs_type: str):
     return device_size > fs_size + block_size
 
 
-def resize_device(device: str, target_mount: str, fs_type: str):
+def resize_device(device: str, target_mount: str, fs_type: str, passphrase=None):
     """Perform resize of the filesystem."""
     if need_resize(device, target_mount, fs_type):
+        if passphrase:
+            luks_manager = LuksManager(logger, device_path=device)
+            luks_manager.luks_resize_device(passphrase)
         if fs_type in ("ext3", "ext4"):
             ext_resize(device)
         elif fs_type == "xfs":

--- a/vast_csi/luks_utils.py
+++ b/vast_csi/luks_utils.py
@@ -1,0 +1,227 @@
+import re
+import json
+from plumbum import local
+from easypy.bunch import Bunch, bunchify
+from easypy.collections import listify
+from vast_csi.filesystem_utils import hostcmd, HostCommand
+from plumbum import local, cmd, ProcessExecutionError
+from vast_csi.logging import logger
+from vast_csi.exceptions import Abort
+from vast_csi.csi_types import NOT_FOUND
+
+def luksDevicePath(volume_name):
+    return f"/dev/mapper/{volume_name}"
+def luksDeviceName(volume_id):
+    return f"vast-csi-crypt-{volume_id}"
+def isHostCryptPath(device, volume_id):
+    return device == luksDevicePath(luksDeviceName(volume_id))
+
+class LuksManager:
+    def __init__(self, logger, vol_id=None, device_path=None, vol_context=None):
+        self.vol_id = vol_id
+        self.encryption_config = self._parse_encryption_config(vol_context or {})
+        self.logger = logger
+        self.device_path = device_path
+        self.luks_device_name = luksDeviceName(vol_id)
+        self.luks_device_path = luksDevicePath(self.luks_device_name)
+
+    @staticmethod
+    def _parse_encryption_config(vol_context):
+        """
+        Extracts host encryption params from the items dictionary.
+
+        Args:
+            items (dict): Dictionary containing volume context or parameters.
+
+        Returns:
+            dict: A dictionary of host encryption parameters without the prefix.
+        """
+        prefix = "host_encryption."
+        return {
+            key[len(prefix):]: value
+            for key, value in vol_context.items()
+            if key.startswith(prefix)
+        }
+
+    def init_host_encryption(self, passphrase: str) -> None:
+        """
+        Handle formatting and opening a LUKS device for a volume if not already done.
+
+        Args:
+            passphrase (str): Passphrase for encryption.
+        """
+        config = self.encryption_config
+        luks_type = config.get("luks_type", "luks2")
+        cipher = config.get("cipher", "aes-xts-plain64")
+        key_size = config.get("key_size", "512")
+        hash_algo = config.get("hash_algo", "sha256")
+        pbkdf_mem = config.get("pbkdf_mem", "65536")
+
+        # Check if LUKS device exists and active
+        is_luks = self._is_luks_device()
+        if not is_luks:
+            # Format and open device
+            self.logger.info(f"Formatting device {self.device_path} with LUKS")
+            self._luks_format_device(
+                passphrase=passphrase,
+                luks_type=luks_type,
+                cipher=cipher,
+                key_size=key_size,
+                hash_algo=hash_algo,
+                pbkdf_mem=pbkdf_mem
+            )
+            self.logger.info(f"Opening encrypted device {self.luks_device_path} as {self.luks_device_name}")
+            self._luks_open_device(
+                passphrase=passphrase
+            )
+            self.logger.info(f"Done opening encrypted device {self.luks_device_path} as {self.luks_device_name}")
+        elif not self._is_luks_active():
+            # Device already LUKS encrypted, but not mapped because it isn't opened yet
+            self.logger.info(f"Opening encrypted device {self.luks_device_path} as {self.luks_device_name}")
+            self._luks_open_device(
+                passphrase=passphrase
+            )
+            self.logger.info(f"Done opening encrypted device {self.luks_device_path} as {self.luks_device_name}")
+        else:
+            # LUKS device exists and active
+            self.logger.info(f"LUKS device already opened at {self.luks_device_path}")
+
+    def _is_luks_device(self) -> bool:
+        """
+        Check if the given device is LUKS-encrypted or not.
+
+        Args:
+            None
+
+        Returns:
+            bool: True if the device is LUKS, False otherwise.
+        """
+        try:
+            hostcmd.cryptsetup("isLuks", self.device_path)
+            return True
+        except ProcessExecutionError:
+            return False
+
+    def _is_luks_active(self) -> bool:
+        """
+        Check if a given LUKS mapping is currently active (opened).
+
+        Args:
+            None
+
+        Returns:
+            bool: True if the LUKS mapping is active, False otherwise.
+        """
+        try:
+            output = hostcmd.cryptsetup("status", self.luks_device_name)
+            return "LUKS2" in output.strip()
+        except ProcessExecutionError:
+            return False
+
+    def fini_host_encryption(self) -> None:
+        """
+        Closes a mapped LUKS device, if open.
+
+        This function delegates to _luks_close_device, which handles
+        closing the LUKS device.
+        """
+        self._luks_close_device()
+
+    def _luks_close_device(self) -> None:
+        """
+        Removes (closes) a mapped LUKS device.
+
+        Args:
+            None
+
+        Raises:
+            Abort: If cryptsetup command fails.
+        """
+        logger.info(f"Attempting to close LUKS device: {self.luks_device_name}")
+        try:
+            hostcmd.cryptsetup("luksClose", self.luks_device_name)
+            self.logger.info(f"LUKS device {self.luks_device_name} closed successfully.")
+        except ProcessExecutionError as e:
+            self.logger.warning(f"Failed to close LUKS device {self.luks_device_name}: {e.stderr.strip() if e.stderr else str(e)}")
+
+    def _luks_open_device(self, passphrase: str) -> None:
+        """
+        Open a LUKS-encrypted device and map it to a specified device name.
+
+        Args:
+            passphrase (str): Passphrase to unlock the LUKS device.
+
+        Raises:
+            Abort: If cryptsetup fails to open the device.
+        """
+        try:
+            hostcmd = HostCommand("cryptsetup")
+            crypt_cmd = hostcmd.get_executable("open", self.device_path, self.luks_device_name)
+            echo_cmd = local["echo"]["-n", passphrase]
+            retcode, stdout, stderr = (echo_cmd | crypt_cmd).run(retcode=None)
+
+        except ProcessExecutionError as e:
+            raise Abort(NOT_FOUND, f"Failed to open LUKS device {device_path}: {e.stderr.strip() if e.stderr else str(e)}")
+
+    def _luks_format_device(self, passphrase: str, luks_type: str, cipher: str,
+                           key_size: str, hash_algo: str,
+                           pbkdf_mem: str) -> None:
+        """
+        Format a block device with LUKS encryption using cryptsetup on the Docker host.
+
+        Args:
+            passphrase (str): Passphrase for LUKS encryption.
+            luks_type (str): LUKS format type (e.g., luks1, luks2).
+            cipher (str): Cipher algorithm to use (e.g., aes-xts-plain64).
+            key_size (str): Key size in bits (e.g., 512).
+            hash_algo (str): Hash algorithm (e.g., sha256).
+            pbkdf_mem (str): PBKDF memory in KB (e.g., 65536).
+
+        Raises:
+            Abort: If cryptsetup fails.
+        """
+        try:
+            hostcmd = HostCommand("cryptsetup")
+            crypt_cmd = hostcmd.get_executable(
+                "luksFormat",
+                "--type", luks_type,
+                "--cipher", cipher,
+                "--key-size", key_size,
+                "--hash", hash_algo,
+                "--pbkdf-memory", pbkdf_mem,
+                "--batch-mode", self.device_path,
+            )
+            echo_cmd = local["echo"]["-n", passphrase]
+            retcode, stdout, stderr = (echo_cmd | crypt_cmd).run(retcode=None)
+
+        except ProcessExecutionError as e:
+            raise Abort(NOT_FOUND, f"LUKS format failed for {self.device_path}: {e.stderr.strip() if e.stderr else str(e)}")
+
+    def luks_resize_device(self, passphrase: str) -> bool:
+        """
+        Resize the LUKS-encrypted device and the filesystem inside it.
+
+        Args:
+            passphrase (str): Passphrase for LUKS encryption.
+
+        Returns:
+            bool: True if the device and filesystem were resized successfully, False otherwise.
+        """
+        if not self._is_luks_device():
+            self.logger.info(f"Device {self.luks_device_path} is not a LUKS-encrypted device.")
+            return False
+
+        try:
+            hostcmd = HostCommand("cryptsetup")
+            crypt_cmd = hostcmd.get_executable(
+                "resize",
+                self.luks_device_path,
+            )
+            echo_cmd = local["echo"]["-n", passphrase]
+            retcode, stdout, stderr = (echo_cmd | crypt_cmd).run(retcode=None)
+            self.logger.info(f"Device {self.luks_device_path} resized successfully")
+            return True
+
+        except ProcessExecutionError as e:
+            self.logger.error(f"Error resizing LUKS device {self.luks_device_path}: {e}")
+            return False

--- a/vast_csi/plugins/base.py
+++ b/vast_csi/plugins/base.py
@@ -68,6 +68,7 @@ class Instrumented:
             params = {fld.name: value for fld, value in request.ListFields()}
             # secrets are not logged and not the part of function signature.
             secrets = params.pop("secrets", {})
+            volume_secret = params.pop("volume_secret", {})
             missing_params = required_params - {"request", "context", "vms_session", "exit_stack"} - set(params)
 
             # Get cluster_name from volume_id, snapshot_id or source_volume_id in case of id identifier with metadata
@@ -93,6 +94,9 @@ class Instrumented:
                 for line in stringify_dict(params):
                     log(f"({method})    {line}")
 
+            if volume_secret:
+                log(f"({method})    volume_secret: <redacted>")
+
             if "vms_session" in required_params:
                 # If secret exist and method signature requires `vms_session`
                 # then `vms_session` with secret will be injected into function parameters
@@ -103,6 +107,12 @@ class Instrumented:
                     params["vms_session"] = get_vms_session(**{k: secrets.get(k) for k in vms_session_args})
                 except LookupFieldError:
                     params["vms_session"] = None
+
+            if "volume_secret" in required_params:
+                params["volume_secret"] = volume_secret
+            elif "volume_secret" in non_required_params:
+                if volume_secret:
+                    params["volume_secret"] = volume_secret
 
             exit_stack = ExitStack()
             if "exit_stack" in required_params:

--- a/vast_csi/plugins/base.py
+++ b/vast_csi/plugins/base.py
@@ -68,7 +68,7 @@ class Instrumented:
             params = {fld.name: value for fld, value in request.ListFields()}
             # secrets are not logged and not the part of function signature.
             secrets = params.pop("secrets", {})
-            volume_secret = params.pop("volume_secret", {})
+            host_encryption_secret = secrets.get("passphrase", None)
             missing_params = required_params - {"request", "context", "vms_session", "exit_stack"} - set(params)
 
             # Get cluster_name from volume_id, snapshot_id or source_volume_id in case of id identifier with metadata
@@ -94,8 +94,8 @@ class Instrumented:
                 for line in stringify_dict(params):
                     log(f"({method})    {line}")
 
-            if volume_secret:
-                log(f"({method})    volume_secret: <redacted>")
+            if host_encryption_secret:
+                log(f"({method})    host_encryption_secret: <redacted>")
 
             if "vms_session" in required_params:
                 # If secret exist and method signature requires `vms_session`
@@ -107,12 +107,6 @@ class Instrumented:
                     params["vms_session"] = get_vms_session(**{k: secrets.get(k) for k in vms_session_args})
                 except LookupFieldError:
                     params["vms_session"] = None
-
-            if "volume_secret" in required_params:
-                params["volume_secret"] = volume_secret
-            elif "volume_secret" in non_required_params:
-                if volume_secret:
-                    params["volume_secret"] = volume_secret
 
             exit_stack = ExitStack()
             if "exit_stack" in required_params:
@@ -365,11 +359,16 @@ class NodeBase(csi_grpc.NodeServicer):
     def _store_meta_file(self, meta_file, volume_id, is_ephemeral, vms_session):
         """
         Stores metadata about a volume in a file, including information about
-        whether the volume is ephemeral and, if so, serialized session data.
+        whether the volume is ephemeral, host_encryption and, if so, serialized session data.
         """
-        payload = dict(volume_id=volume_id, is_ephemeral=is_ephemeral)
+        payload = {
+        "volume_id": volume_id,
+        "is_ephemeral": is_ephemeral,
+        }
+
         if is_ephemeral:
             payload["vms_session"] = vms_session.serialize(salt=volume_id)
+
         with meta_file.open("w") as f:
             json.dump(payload, f)
         os.chmod(meta_file, 0o600)
@@ -396,4 +395,5 @@ class NodeBase(csi_grpc.NodeServicer):
             self.controller.DeleteVolume.__wrapped__(
                 self.controller, vms_session=vms_session, volume_id=meta["volume_id"]
             )
+
         return meta

--- a/vast_csi/plugins/block.py
+++ b/vast_csi/plugins/block.py
@@ -25,6 +25,7 @@ from easypy.caching import cached_property
 from vast_csi.logging import logger
 from vast_csi.proto import csi_pb2_grpc as csi_grpc
 from vast_csi import csi_types as types
+from vast_csi.luks_utils import LuksManager, isHostCryptPath
 from vast_csi.csi_types import (
     INVALID_ARGUMENT,
     ALREADY_EXISTS,
@@ -53,8 +54,6 @@ from vast_csi.block_utils import (
     try_nvme_probes,
     change_io_policy,
     is_native_multipath_enabled,
-    is_luks_device,
-    is_luks_crypto,
 )
 from vast_csi.utils import (
     stringify_dict,
@@ -304,6 +303,7 @@ class BlockController(ControllerBase, Instrumented):
         transport_type = volume_context["transport_type"]
         vol_id = int(volume_context["volume_id"])
         tenant_name = volume_context["tenant_name"]
+        host_encryption = volume_context.get("host_encryption", False)
         blockhost = vms_session.blockhosts.ensure(
             node_id=node_id,
             tenant_name=tenant_name,
@@ -315,7 +315,6 @@ class BlockController(ControllerBase, Instrumented):
         )
         vip_pool_name = volume_context.get("vip_pool_name")
         vip_pool_fqdn = volume_context.get("vip_pool_fqdn")
-        volume_encryption = volume_context.get("volume_encryption")
         if vip_pool_fqdn:
             discovery_server = vip_pool_fqdn
         elif vip_pool_name:
@@ -332,8 +331,12 @@ class BlockController(ControllerBase, Instrumented):
                 host_nqn=blockhost.nqn,
                 nguid=nguid,
                 discovery_server=discovery_server,
-                volume_encryption=volume_encryption
             )
+
+        if isinstance(host_encryption, dict):
+            for k, v in host_encryption.items():
+                publish_context[f"host_encryption.{k}"] = str(v)
+
         return types.CtrlPublishResp(publish_context=publish_context)
 
     def ControllerUnpublishVolume(self, vms_session, node_id, volume_id):
@@ -430,7 +433,6 @@ class BlockNode(NodeBase, Instrumented):
             vms_session=None,
             publish_context=None,
             volume_context=None,
-            volume_secret=None,
     ):
         exit_stack.enter_context(volume_locked(volume_id))
         volume_context = volume_context or dict()
@@ -455,7 +457,6 @@ class BlockNode(NodeBase, Instrumented):
         host_nqn = publish_context["host_nqn"]
         nguid = publish_context["nguid"]
         discovery_server = publish_context["discovery_server"]  # Either vip pool ip or fqdn
-        volume_encryption = publish_context["volume_encryption"]
         need_resize = volume_context.get("need_resize", False)
 
         if nvme_session := get_connected_session(host_nqn=host_nqn, sybsystem_nqn=subsystem_nqn):
@@ -485,36 +486,15 @@ class BlockNode(NodeBase, Instrumented):
         device_path = device.DevicePath
         change_io_policy(device_name=device.Name, io_policy="round-robin")
 
-        if volume_encryption:
-            luks_device_name = f"crypt-{volume_id}"
-            luks_device_path = f"/dev/mapper/{luks_device_name}"
+        host_encryption_present = any(key.startswith("host_encryption.") for key in volume_context)
+        passphrase = getattr(vms_session, "passphrase", None)
+        if host_encryption_present:
+            if not passphrase:
+                raise Abort(INVALID_ARGUMENT, "Host encryption detected, but 'host_encryption_secret' not provided. Please provide a passphrase for the encrypted volume.")
 
-            if volume_secret:
-                passphrase = volume_secret.get("passphrase")
-                if not passphrase:
-                    raise Abort(INVALID_ARGUMENT, "Missing passphrase for encrypted volume")
-            else:
-                raise Abort(INVALID_ARGUMENT, "Volume encryption detected, but 'volume_secret' not provided. Please provide a passphrase for the encrypted volume.")
-
-            if not os.path.exists(luks_device_path):
-                is_luks = is_luks_device() and is_luks_crypto()
-
-                if not is_luks:
-                    logger.info(f"Formatting device {device_path} with LUKS")
-                    try:
-                        hostcmd.run(["cryptsetup", "luksFormat", "--batch-mode", device_path], input=passphrase.encode())
-                    except ProcessExecutionError as e:
-                        raise Abort(INTERNAL, f"LUKS format failed for {device_path}: {e.stderr.strip()}")
-
-                logger.info(f"Opening encrypted device {device_path} as {luks_device_name}")
-                try:
-                    hostcmd.run(["cryptsetup", "open", device_path, luks_device_name], input=passphrase.encode())
-                except ProcessExecutionError as e:
-                    raise Abort(INTERNAL, f"Failed to open LUKS device {device_path}: {e.stderr.strip()}")
-            else:
-                logger.info(f"LUKS device already opened at {luks_device_path}")
-
-            device_path = luks_device_path
+            luks_manager = LuksManager(logger, volume_id, device_path, volume_context)
+            luks_manager.init_host_encryption(passphrase=passphrase)
+            device_path = luks_manager.luks_device_path
 
         if volume_capabilities.is_filesystem:
             fs_type = volume_capabilities.fs_type
@@ -531,7 +511,7 @@ class BlockNode(NodeBase, Instrumented):
                 with temporary_mount(
                         src=device_path, tgt_dir=staging_target_path, fs_type=fs_type
                 ) as temp_mount:
-                    resize_device(device=device_path, target_mount=temp_mount, fs_type=fs_type)
+                    resize_device(device=device_path, target_mount=temp_mount, fs_type=fs_type, passphrase=passphrase)
 
         logger.info(f"Binding device at {device_path} to {device_bind_path}.")
         device_bind_path.open("a").close()
@@ -542,6 +522,7 @@ class BlockNode(NodeBase, Instrumented):
         staging_target_path = local.path(staging_target_path)
         device_bind_path = get_device_bind_path(staging_target_path)
         staging_mount, target_mounts = MountInfo.get_mounts_by_source(src=device_bind_path)
+
         if target_mounts:
             targets_mount_points = ", ".join(mount.mount_point for mount in target_mounts)
             logger.info(f"Staging path {device_bind_path} is being used by {targets_mount_points} targets.")
@@ -550,6 +531,11 @@ class BlockNode(NodeBase, Instrumented):
             umount_safe(device_bind_path)
         else:
             logger.info(f"Device not found at {device_bind_path}")
+
+        # If device is encrypted teardown accordingly
+        if isHostCryptPath(device_bind_path, volume_id):
+            with LuksManager(logger, volume_id) as lm:
+                lm.fini_host_encryption()
         remove_path_if_not_mounted(device_bind_path)
         return types.UnstageResp()
 
@@ -574,6 +560,7 @@ class BlockNode(NodeBase, Instrumented):
 
         volume_capabilities = _validate_capabilities(volume_capability, volume_context, publish_context)
         is_ephemeral = volume_context.get("csi.storage.k8s.io/ephemeral") == "true"
+        host_encryption_present = any(key.startswith("host_encryption.") for key in volume_context)
         if is_ephemeral:
             if not vms_session:
                 raise Exception(
@@ -629,7 +616,7 @@ class BlockNode(NodeBase, Instrumented):
                 meta_file=meta_file,
                 volume_id=volume_id,
                 is_ephemeral=is_ephemeral,
-                vms_session=vms_session
+                vms_session=vms_session,
             )
             try:
                 mount(src=device_bind_path, tgt=target_path, flags=mount_flags, fs_type=fs_type)

--- a/vast_csi/plugins/block.py
+++ b/vast_csi/plugins/block.py
@@ -53,6 +53,8 @@ from vast_csi.block_utils import (
     try_nvme_probes,
     change_io_policy,
     is_native_multipath_enabled,
+    is_luks_device,
+    is_luks_crypto,
 )
 from vast_csi.utils import (
     stringify_dict,
@@ -313,6 +315,7 @@ class BlockController(ControllerBase, Instrumented):
         )
         vip_pool_name = volume_context.get("vip_pool_name")
         vip_pool_fqdn = volume_context.get("vip_pool_fqdn")
+        volume_encryption = volume_context.get("volume_encryption")
         if vip_pool_fqdn:
             discovery_server = vip_pool_fqdn
         elif vip_pool_name:
@@ -329,6 +332,7 @@ class BlockController(ControllerBase, Instrumented):
                 host_nqn=blockhost.nqn,
                 nguid=nguid,
                 discovery_server=discovery_server,
+                volume_encryption=volume_encryption
             )
         return types.CtrlPublishResp(publish_context=publish_context)
 
@@ -426,6 +430,7 @@ class BlockNode(NodeBase, Instrumented):
             vms_session=None,
             publish_context=None,
             volume_context=None,
+            volume_secret=None,
     ):
         exit_stack.enter_context(volume_locked(volume_id))
         volume_context = volume_context or dict()
@@ -450,6 +455,7 @@ class BlockNode(NodeBase, Instrumented):
         host_nqn = publish_context["host_nqn"]
         nguid = publish_context["nguid"]
         discovery_server = publish_context["discovery_server"]  # Either vip pool ip or fqdn
+        volume_encryption = publish_context["volume_encryption"]
         need_resize = volume_context.get("need_resize", False)
 
         if nvme_session := get_connected_session(host_nqn=host_nqn, sybsystem_nqn=subsystem_nqn):
@@ -478,6 +484,37 @@ class BlockNode(NodeBase, Instrumented):
 
         device_path = device.DevicePath
         change_io_policy(device_name=device.Name, io_policy="round-robin")
+
+        if volume_encryption:
+            luks_device_name = f"crypt-{volume_id}"
+            luks_device_path = f"/dev/mapper/{luks_device_name}"
+
+            if volume_secret:
+                passphrase = volume_secret.get("passphrase")
+                if not passphrase:
+                    raise Abort(INVALID_ARGUMENT, "Missing passphrase for encrypted volume")
+            else:
+                raise Abort(INVALID_ARGUMENT, "Volume encryption detected, but 'volume_secret' not provided. Please provide a passphrase for the encrypted volume.")
+
+            if not os.path.exists(luks_device_path):
+                is_luks = is_luks_device() and is_luks_crypto()
+
+                if not is_luks:
+                    logger.info(f"Formatting device {device_path} with LUKS")
+                    try:
+                        hostcmd.run(["cryptsetup", "luksFormat", "--batch-mode", device_path], input=passphrase.encode())
+                    except ProcessExecutionError as e:
+                        raise Abort(INTERNAL, f"LUKS format failed for {device_path}: {e.stderr.strip()}")
+
+                logger.info(f"Opening encrypted device {device_path} as {luks_device_name}")
+                try:
+                    hostcmd.run(["cryptsetup", "open", device_path, luks_device_name], input=passphrase.encode())
+                except ProcessExecutionError as e:
+                    raise Abort(INTERNAL, f"Failed to open LUKS device {device_path}: {e.stderr.strip()}")
+            else:
+                logger.info(f"LUKS device already opened at {luks_device_path}")
+
+            device_path = luks_device_path
 
         if volume_capabilities.is_filesystem:
             fs_type = volume_capabilities.fs_type

--- a/vast_csi/vms_session.py
+++ b/vast_csi/vms_session.py
@@ -132,12 +132,13 @@ def _derive_key(salt):
 
 
 @locking_cache
-def get_vms_session(username=None, password=None, endpoint=None, ssl_cert=None, cluster_name=None):
+def get_vms_session(username=None, password=None, endpoint=None, ssl_cert=None, cluster_name=None, passphrase=None):
     config = Config()
     session_cls = TestVmsSession if config.mock_vast else VmsSession
     return session_cls.create(
         config=config, username=username, password=password,
         endpoint=endpoint, ssl_cert=ssl_cert, cluster_name=cluster_name,
+        passphrase=passphrase,
     )
 
 
@@ -216,13 +217,14 @@ class VmsSession(RESTSession):
     Communication with vms cluster.
     Operations over vip pools, quotas, snapshots etc.
     """
-    def __init__(self, config, username, password, endpoint, ssl_cert):
+    def __init__(self, config, username, password, endpoint, ssl_cert, passphrase=None):
         super().__init__(config)
         self.username = username
         self.password = password
         self.endpoint = endpoint
         self.ssl_cert = ssl_cert
         self.base_url = f"https://{endpoint}/api"
+        self.passphrase = passphrase
         # Modify the SSL verification CA bundle path established
         # by the underlying Certifi library's defaults if ssl_verify==True.
         certs_base_dir = "/etc/ssl/certs"
@@ -258,7 +260,7 @@ class VmsSession(RESTSession):
         self.blockhostmappings = BlockHostMapping(self)
 
     def serialize(self, salt: str):
-        session_data = pickle.dumps((self.username, self.password, self.endpoint, self.ssl_cert))
+        session_data = pickle.dumps((self.username, self.password, self.endpoint, self.ssl_cert, self.passphrase))
         iv = os.urandom(16)
         key = _derive_key(salt)
         cipher = Cipher(algorithms.AES(key), modes.CFB(iv), backend=default_backend())
@@ -280,10 +282,10 @@ class VmsSession(RESTSession):
         # Decrypt the data
         plainbytes = decryptor.update(ciphertext) + decryptor.finalize()
         username, password, endpoint, ssl_cert = pickle.loads(plainbytes)
-        return get_vms_session(username=username, password=password, endpoint=endpoint, ssl_cert=ssl_cert)
+        return get_vms_session(username=username, password=password, endpoint=endpoint, ssl_cert=ssl_cert, passphrase=passphrase)
 
     @classmethod
-    def create(cls, config, username, password, endpoint, ssl_cert, cluster_name):
+    def create(cls, config, username, password, endpoint, ssl_cert, cluster_name, passphrase=None):
         """
         Creates an instance of the session, initializing credentials based on provided arguments or configuration context.
 
@@ -330,6 +332,7 @@ class VmsSession(RESTSession):
             username = cluster_auth_config.username
             password = cluster_auth_config.password
             endpoint = cluster_auth_config.endpoint
+            passphrase = cluster_auth_config.passphrase
             config_source = f"multi-cluster auth configuration ({cluster_name=})"
         else:
             # The presence of the name in the arguments already indicates
@@ -340,6 +343,7 @@ class VmsSession(RESTSession):
                 username = config.vms_user
                 password = config.vms_password
                 endpoint = config.vms_host
+                passphrase = config.passphrase
                 if not endpoint:
                     raise LookupFieldError(field="endpoint", tip="Make sure endpoint is specified in values.yaml.")
             if not username:
@@ -350,7 +354,7 @@ class VmsSession(RESTSession):
                 raise LookupFieldError(field="endpoint",  tip="Make sure endpoint is present in secret.")
             config_source = "mounted credentials (global secret)" if is_global else "StorageClass secret"
 
-        session = cls(config, username, password, endpoint, ssl_cert)
+        session = cls(config, username, password, endpoint, ssl_cert, passphrase)
         ssl_verification = "enabled" if session.ssl_verify else "disabled"
         logger.info(f"VMS session has been instantiated from {config_source}. SSL verification {ssl_verification}.")
         return session


### PR DESCRIPTION
This PR introduces host-side encryption support for block volumes using the dm-crypt module. Host encryption is disabled by default and can be enabled by setting the `host_encryption` parameter in the StorageClass.

When enabled, the NVMe device discovered via NVMe-TCP is encrypted on the client side using dm-crypt.

To use this feature, users must provide a Kubernetes secret referenced in the StorageClass containing a `passphrase` field.